### PR TITLE
Add improved scene generation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# infiniti-v
+# Infiniti-V
+
+This project provides a small Flask backend for generating a JSON scene script from a one-sentence prompt. The current code simulates the ∞‑V multi-agent pipeline and can later be extended with real language models.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   python app.py
+   ```
+3. Send a POST request to `/generate_scene` with a JSON body containing a `prompt` field.
+
+The response is a list of dialogue and action blocks in the ∞‑VScript format.
+
+### Example
+
+```bash
+curl -X POST http://localhost:5000/generate_scene \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "A teacher explains gravity to students in a treehouse."}'
+```
+
+The server responds with JSON similar to:
+
+```json
+[
+  {"id": "1", "type": "dialogue", "character": "Teacher", "text": "This is line 1 about A teacher explains gravity to students", "duration": 3.0},
+  {"id": "5", "type": "action", "description": "Teacher gestures while speaking.", "timing": "after"}
+]
+```

--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,135 @@
+"""Multi-agent scene generation helpers."""
+
+import os
+import itertools
+from typing import List, Dict
+
+# Placeholder environment variables for API keys
+GROQ_API_KEY = os.getenv('GROQ_API_KEY')
+ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')
+LETTA_API_KEY = os.getenv('LETTA_API_KEY')
+
+
+def interpret_prompt(prompt: str) -> Dict:
+    """Parse the user prompt to determine topic, setting and characters."""
+
+    clean = prompt.strip()
+    topic = clean
+    setting = "unknown"
+
+    # Very light parsing for "<topic> in <setting>" prompts
+    if " in " in clean:
+        first, setting_part = clean.split(" in ", 1)
+        topic = first.rstrip(".")
+        setting = setting_part.rstrip(".")
+    else:
+        topic = clean.rstrip('.')
+
+    characters: List[Dict] = []
+    lower = clean.lower()
+    if "teacher" in lower:
+        characters.append({"name": "Teacher", "role": "teacher", "traits": {}})
+    if "student" in lower:
+        characters.append({"name": "Student", "role": "student", "traits": {}})
+    if not characters:
+        characters.append({"name": "Narrator", "role": "narrator", "traits": {}})
+
+    return {
+        "scene_topic": topic.capitalize(),
+        "setting": setting,
+        "scene_type": "conversation",
+        "characters": characters,
+        "target_length_seconds": 150,
+    }
+
+
+def web_search(scene_topic: str, setting: str) -> Dict:
+    """Stub for a web search agent using Letta."""
+
+    # Internet access is blocked so we return dummy references.
+    return {
+        "references": [
+            f"Facts about {scene_topic} gleaned from a web search.",
+            f"Information about {setting} for background."
+        ],
+        "images": [],
+    }
+
+
+def plan_scene(metadata: Dict, references: Dict) -> Dict:
+    """Create a lightweight scene plan based on metadata."""
+
+    flow = ["intro", "concept", "reaction", "wrap"]
+
+    # Basic estimate: 8 dialogue turns for a short 2 minute scene
+    turns = 8
+
+    return {
+        "scene_title": metadata["scene_topic"],
+        "background": metadata["setting"],
+        "flow": flow,
+        "dialogue_turns": turns,
+        "camera_plan": ["wide", "close-up", "medium", "wide"],
+    }
+
+
+def generate_dialogue(characters: List[Dict], turns: int, topic: str) -> List[Dict]:
+    """Create simple dialogue lines cycling through characters."""
+
+    speakers = itertools.cycle(characters)
+    lines: List[Dict] = []
+
+    for i in range(1, turns + 1):
+        speaker = next(speakers)
+        text = f"This is line {i} about {topic}."
+        duration = max(1.5, 0.15 * len(text.split()))
+
+        lines.append(
+            {
+                "id": str(len(lines) + 1),
+                "type": "dialogue",
+                "character": speaker["name"],
+                "traits": speaker["traits"],
+                "emotion": "neutral",
+                "text": text,
+                "duration": round(duration, 2),
+                "voice_url": "",
+            }
+        )
+
+    return lines
+
+
+def add_actions(dialogue: List[Dict], characters: List[Dict]) -> List[Dict]:
+    """Attach a basic gesture action after each dialogue block."""
+
+    actions: List[Dict] = []
+    for idx, line in enumerate(dialogue, 1):
+        actions.append(
+            {
+                "id": str(len(dialogue) + idx),
+                "type": "action",
+                "description": f"{line['character']} gestures while speaking.",
+                "timing": "after",
+            }
+        )
+    return actions
+
+
+def structure_script(dialogue: List[Dict], actions: List[Dict]) -> List[Dict]:
+    """Combine dialogue and action blocks into a single list."""
+
+    return dialogue + actions
+
+
+def run_pipeline(prompt: str) -> List[Dict]:
+    """Execute the pipeline of agents to build a script."""
+
+    meta = interpret_prompt(prompt)
+    refs = web_search(meta["scene_topic"], meta["setting"])
+    plan = plan_scene(meta, refs)
+    dialogue = generate_dialogue(
+        meta["characters"], plan["dialogue_turns"], meta["scene_topic"]
+    )
+    actions = add_actions(dialogue, meta["characters"])
+    return structure_script(dialogue, actions)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,21 @@
+"""Flask entry point for the ∞‑V script generation pipeline."""
+
+import os
+from flask import Flask, request, jsonify
+from agents import run_pipeline
+
+app = Flask(__name__)
+
+@app.route('/generate_scene', methods=['POST'])
+def generate_scene():
+    """Generate a script from a single-sentence prompt."""
+
+    data = request.get_json(silent=True)
+    if not data or 'prompt' not in data:
+        return jsonify({'error': 'Missing prompt'}), 400
+
+    script = run_pipeline(data['prompt'])
+    return jsonify(script)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.getenv('PORT', 5000)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests


### PR DESCRIPTION
## Summary
- refine agents with typed functions and docstrings
- expand README with example usage
- add comments to Flask entry point

## Testing
- `python -m py_compile app.py agents.py`
- `pip install -r requirements.txt`
- `python` Flask test client request to `/generate_scene`


------
https://chatgpt.com/codex/tasks/task_e_68572b072448832aa58fe96b2d208a25