### PR TITLE
Add real LLM and search agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project provides a small Flask backend for generating a JSON scene script from a one-sentence prompt. The current code simulates the ∞‑V multi-agent pipeline and can later be extended with real language models.
 
+The latest version can optionally call real language models and a search API.
+Set one of `GROQ_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` for LLM
+access. A `LETTA_API_KEY` enables web search support.
+
 ## Usage
 
 1. Install dependencies:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 requests
+openai


### PR DESCRIPTION
## Summary
- add `openai` dependency
- update README with environment variables for agents
- implement LLM querying via Groq, OpenAI, or Anthropic
- implement real web search via Letta API
- generate dialogue and plans using live models when keys are available

## Testing
- `python -m py_compile agents.py app.py`
- `pip install --no-cache-dir -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6857324c7a38832a8a9a90cc5b331f1c